### PR TITLE
finish partial stripQuotes implementation

### DIFF
--- a/tests/test_schema_parser.nim
+++ b/tests/test_schema_parser.nim
@@ -130,6 +130,17 @@ UnitTestSuite("Schema parser"):
       parser(";;;") == (columnA: "", columnB: "", columnC: "")
       parser(" ; ; ") == (columnA: " ", columnB: " ", columnC: " ")
 
+  test "Pure string column (stripQuotes)":
+    const schema = [
+      strCol("columnA"),
+      strCol("columnB", stripQuotes = true)
+    ]
+    let parser = schemaParser(schema, ';')
+    check:
+      parser("hello;world") == (columnA: "hello", columnB: "world")
+      parser("\"hello\";\"world\"") == (columnA: "\"hello\"", columnB: "world")
+      parser("'hello';'world'") == (columnA: "'hello'", columnB: "world")
+
   # ---------------------------------------------------------------------------
   # int
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
`stripQuotes` was already present in the `strCol` schema field definition, however it wasn't actually implemented. This adds the stripping of quotes (either ' or ") by enabling the `stripQuotes` argument.

