### PR TITLE
show custom width

### DIFF
--- a/src/nimdata.nim
+++ b/src/nimdata.nim
@@ -556,13 +556,14 @@ proc separatorRowIntercepted(sizes: seq[int], interceptor: char): string =
     result &= '-'.repeat(size + 2)
     result &= interceptor
 
-proc show*[T: tuple](df: DataFrame[T], s: Stream = nil) =
+proc show*[T: tuple](df: DataFrame[T], s: Stream = nil, width = 10) =
   ## Prints the content of the data frame in the form of an ASCII table.
   ## If no stream is specified, the output is written to ``stdout``.
+  ## Fields are truncated at `width` characters (by default `10`).
   var dummy: T
   var i = 0
   let fields = getFields(T)
-  let sizes = 10.repeat(fields.len)
+  let sizes = width.repeat(fields.len)
   var stream: Stream
 
   if s.isNil:

--- a/tests/test_show.nim
+++ b/tests/test_show.nim
@@ -1,6 +1,7 @@
 import nimdata
 import nimdata/utils
 import streams
+import strutils
 
 UnitTestSuite("Show"):
 
@@ -43,3 +44,19 @@ UnitTestSuite("Show"):
       (f32: 1f32, f64: 1f64, i8: 1i8, i16: 1i16, i32: 1i32, i64: 1i64),
     ]
     DF.fromSeq(data3).show(stdoutDummy)
+
+  test "Custom width":
+    var s = newStringStream()
+    let data1 = @[
+      (name: "Bob", age: 99, testWithLongColumn: 1.112341975, anotherCol: "with very long strings"),
+      (name: "Joe", age: 11, testWithLongColumn: 1.1,         anotherCol: "short"),
+    ]
+    DF.fromSeq(data1).show(s, width = 12)
+    s.setPosition(0)
+    check: s.readAll() == """+--------------+--------------+--------------+--------------+
+      | name         |          age | testWithLon… | anotherCol   |
+      +--------------+--------------+--------------+--------------+
+      | Bob          |           99 |  1.112341975 | with very l… |
+      | Joe          |           11 |          1.1 | short        |
+      +--------------+--------------+--------------+--------------+
+    """.unindent()


### PR DESCRIPTION
The hardcoded field width of `10` is giving me issues in my current analysis (my key field are typically 12 characters wide. This allows you to customize the field width beyond which the truncation will happen in the ASCII table. The default width is still at `10`.

Example:
```
DF.fromSeq(data1).show(width = 12)
```

