### PR TITLE
add basic plotting support for dataframes via plotly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,11 @@ install:
     fi
     cd ..
 before_script:
-    - export PATH="nim-$BRANCH/bin${PATH:+:$PATH}"
+    - export PATH="/home/travis/build/bluenote10/NimData/nim-$BRANCH/bin${PATH:+:$PATH}"
+    - which nimble
+    - which nim
+    - pwd
+    #- export NIM_LIB_PREFIX="nim-$BRANCH/lib"
 script:
     - |
       nimble install -y
@@ -56,4 +60,3 @@ notifications:
   email:
     recipients:
       - contact@zentabs.com
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,6 @@ install:
     cd ..
 before_script:
     - export PATH="/home/travis/build/bluenote10/NimData/nim-$BRANCH/bin${PATH:+:$PATH}"
-    - which nimble
-    - which nim
-    - pwd
-    #- export NIM_LIB_PREFIX="nim-$BRANCH/lib"
 script:
     - |
       nimble install -y

--- a/examples/example_01.nim
+++ b/examples/example_01.nim
@@ -36,9 +36,7 @@ proc example01*() =
   df.toCsv("table.csv")
   df.openInBrowser()
 
-
 proc example02*() =
-
   # Load a CSV
   let dfRawText = DF.fromFile("examples/Bundesliga.csv")
 
@@ -132,6 +130,49 @@ proc example02*() =
       count: x.count
     ))
     .take(5)
+    .show()
+
+  # lets look at the 15 most successful home teams
+  df.filter(record => record.homeGoals > record.awayGoals)
+    .map(record => record.projectTo(homeTeam))
+    .valueCounts()
+    .sort(x => x.count, SortOrder.Descending)
+    .map(x => (
+      homeTeam: x.key.homeTeam,
+      count: x.count
+    ))
+    .take(15)
+    .barPlot(x = homeTeam, y = count)
+    .show()
+
+  # a scatter plots of homeGoals / awayGoals
+  df.scatterPlot(x = homeGoals, y = awayGoals)
+    .show()
+
+  # and a heatmap of these
+  df.map(record => record.projectTo(homeGoals, awayGoals))
+    .valueCounts()
+    .sort(x => x.count, SortOrder.Descending)
+    .map(x => (
+      homeGoals: x.key.homeGoals,
+      awayGoals: x.key.awayGoals,
+      count: x.count
+    ))
+    .heatmap(x = homeGoals, y = awayGoals, z = count)
+    .show()
+
+  # alternatively a coloread scatter plot of the same, with the
+  # number of occurences as the color of the marker
+  df.map(record => record.projectTo(homeGoals, awayGoals))
+    .valueCounts()
+    .sort(x => x.count, SortOrder.Descending)
+    .map(x => (
+      homeGoals: x.key.homeGoals,
+      awayGoals: x.key.awayGoals,
+      count: x.count
+    ))
+    .scatterColor(x = homeGoals, y = awayGoals, z = count)
+    .markerSize(20)
     .show()
 
   # To open data frame in browser:

--- a/nimdata.nimble
+++ b/nimdata.nimble
@@ -11,6 +11,7 @@ binDir = "bin"
 # Dependencies
 requires "nim >= 0.16.0"
 requires "zip >= 0.1.1"
+requires "plotly"
 
 
 import strutils
@@ -50,4 +51,3 @@ task tests, "Runs unit tests":
     # This does currently not make sense, due to include only source files:
     # for f in iterateSourceFiles(thisDir()):
     #   runTest(f)
-

--- a/nimdata.nimble
+++ b/nimdata.nimble
@@ -38,7 +38,7 @@ proc runTest(file: string) =
   var cc = getEnv("CC")
   if cc == "":
     cc = "gcc"
-  exec "nim c --cc:" & cc & " --verbosity:0 -r -d:testNimData -o:bin/tests " & file
+  exec "nim c --cc:" & cc & " --verbosity:0 -r -d:travis -d:testNimData -o:bin/tests " & file
 
 task tests, "Runs unit tests":
   # TODO: How can I ensure nimble installs deps before running this?

--- a/src/nimdata.nim
+++ b/src/nimdata.nim
@@ -44,6 +44,9 @@ import browsers
 import sets
 import tables
 
+import nimdata/basetypes
+export basetypes
+
 import nimdata/schema_parser
 export schema_parser.strCol
 export schema_parser.intCol
@@ -58,8 +61,11 @@ export tuples.projectAway
 export tuples.addField
 export tuples.addFields
 
+include nimdata/plotting
+
 export SortOrder
 export `=>`
+export map
 
 import nimdata/io_gzip
 import nimdata/html
@@ -67,8 +73,6 @@ import nimdata/utils
 
 
 type
-  DataFrame*[T] = ref object of RootObj
-
   CachedDataFrame[T] = ref object of DataFrame[T]
     data: seq[T]
 
@@ -756,9 +760,6 @@ proc openInBrowser*[T: tuple|object](df: DataFrame[T]) =
 # Specialized DataFrame types
 # (definition down here because of https://github.com/nim-lang/Nim/issues/5325)
 # -----------------------------------------------------------------------------
-
-type
-  DataFrameContext* = object
 
 let
   DF* = DataFrameContext()

--- a/src/nimdata/basetypes.nim
+++ b/src/nimdata/basetypes.nim
@@ -1,0 +1,8 @@
+type
+  DataFrame*[T] = ref object of RootObj
+
+# -----------------------------------------------------------------------------
+# Specialized DataFrame types
+# -----------------------------------------------------------------------------
+
+  DataFrameContext* = object

--- a/src/nimdata/plotting.nim
+++ b/src/nimdata/plotting.nim
@@ -17,7 +17,7 @@ template barPlot*[T](df: DataFrame[T], x, y: untyped): untyped =
 
 template histPlot*[T](df: DataFrame[T], hist: untyped): untyped =
   let data = df.collect()
-  let histData = data.map(r => r.hist.float)
+  let histData = data.map(r => r.hist)
   let title = "Histogram of " & astToStr(hist)
   histPlot(histData)
     .title(title)
@@ -36,8 +36,8 @@ template heatmap*[T](df: DataFrame[T], x, y, z: untyped): untyped =
 
 template scatterPlot*[T](df: DataFrame[T], x, y: untyped): untyped =
   let data = df.collect()
-  let xData = data.map(r => r.x.float)
-  let yData = data.map(r => r.y.float)
+  let xData = data.map(r => r.x)
+  let yData = data.map(r => r.y)
   let title = "Scatter plot of " & astToStr(x) & " vs. " & astToStr(y)
   scatterPlot(xData, yData)
     .title(title)
@@ -47,9 +47,9 @@ template scatterPlot*[T](df: DataFrame[T], x, y: untyped): untyped =
 template scatterColor*[T](df: DataFrame[T], x, y, z: untyped): untyped =
   ## adds a color dimension to the scatter plot in addition
   let data = df.collect()
-  let xData = data.map(r => r.x.float)
-  let yData = data.map(r => r.y.float)
-  let zData = data.map(r => r.z.float)
+  let xData = data.map(r => r.x)
+  let yData = data.map(r => r.y)
+  let zData = data.map(r => r.z)
   let title = "Scatter plot of " & astToStr(x) & " vs. " & astToStr(y) &
     " with colorscale of " & astToStr(z)
   scatterColor(xData, yData, zData)

--- a/src/nimdata/plotting.nim
+++ b/src/nimdata/plotting.nim
@@ -1,0 +1,58 @@
+import sugar
+import sequtils
+export map
+
+import plotly
+export plotly
+
+template barPlot*[T](df: DataFrame[T], x, y: untyped): untyped =
+  let data = df.collect()
+  let xData = data.map(r => r.x)
+  let yData = data.map(r => r.y)
+  let title = "Bar plot of " & astToStr(x) & " vs. " & astToStr(y)
+  barPlot(xData, yData)
+    .title(title)
+    .xlabel(astToStr(x))
+    .ylabel(astToStr(y))
+
+template histPlot*[T](df: DataFrame[T], hist: untyped): untyped =
+  let data = df.collect()
+  let histData = data.map(r => r.hist.float)
+  let title = "Histogram of " & astToStr(hist)
+  histPlot(histData)
+    .title(title)
+    .xlabel(astToStr(hist))
+
+template heatmap*[T](df: DataFrame[T], x, y, z: untyped): untyped =
+  let data = df.collect()
+  let xData = data.map(r => r.x)
+  let yData = data.map(r => r.y)
+  let zData = data.map(r => r.z)
+  let title = "Heatmap of " & astToStr(x) & " vs. " & astToStr(y) & " on " & astToStr(z)
+  heatmap(xData, yData, zData)
+    .title(title)
+    .xlabel(astToStr(x))
+    .ylabel(astToStr(y))
+
+template scatterPlot*[T](df: DataFrame[T], x, y: untyped): untyped =
+  let data = df.collect()
+  let xData = data.map(r => r.x.float)
+  let yData = data.map(r => r.y.float)
+  let title = "Scatter plot of " & astToStr(x) & " vs. " & astToStr(y)
+  scatterPlot(xData, yData)
+    .title(title)
+    .xlabel(astToStr(x))
+    .ylabel(astToStr(y))
+
+template scatterColor*[T](df: DataFrame[T], x, y, z: untyped): untyped =
+  ## adds a color dimension to the scatter plot in addition
+  let data = df.collect()
+  let xData = data.map(r => r.x.float)
+  let yData = data.map(r => r.y.float)
+  let zData = data.map(r => r.z.float)
+  let title = "Scatter plot of " & astToStr(x) & " vs. " & astToStr(y) &
+    " with colorscale of " & astToStr(z)
+  scatterColor(xData, yData, zData)
+    .title(title)
+    .xlabel(astToStr(x))
+    .ylabel(astToStr(y))


### PR DESCRIPTION
And here goes the final one.

Some basic plotting support for the (I guess) general cases. It's based on this PR:
https://github.com/brentp/nim-plotly/pull/29
so until that is merged, this isn't ready.

Unfortunately I had to move the `DataFrame` definition to a new file and couldn't import `plotting.nim`, but had to include it, because of the definition of `collect`. But I didn't want to dump these into `nimdata.nim` directly.

All plotting templates return a `Plot[T]` object, which can be either stored in a variable and modified / more traces added, or the helper templates (which are also used in the definitions) can be further used. See the added examples.