### PR TITLE
create schema from file header

### DIFF
--- a/src/nimdata/schema_parser.nim
+++ b/src/nimdata/schema_parser.nim
@@ -371,23 +371,29 @@ macro schemaParser*(schema: static[openarray[Column]], sep: static[char]): untyp
     #echo result.treerepr
     echo result.repr
 
-proc createSchemaFromHeader*(file: string,sep = ';'): seq[Column] =
-  ## Creates a schema from the header line of a file.
-  ## Every column is created as a ```strCol``.
-  ##
-  ## This is useful if you want to read a file
-  ## and filter out columns before manualy creating a schema.
-  let header = staticRead(file).splitLines[0].split(sep)
+proc createSchemaFromHeader*(header: string,sep = ';'): seq[Column] =
+  ## Creates a schema with string-columns from a string with column names seperated by ```sep```.
+  ## This can be used to copy-paste the header of a large file and create columns from it.
   var i = 0
-  for str in header:
+  for str in header.split(sep):
       if str == "":
           result.add(strCol("unnamed" & $i))
           i += 1
       else:
           result.add(strCol(str))
+
+template createSchemaFromHeaderFile*(file: string,sep = ';'): seq[Column] =
+  ## Creates a schema from the header line of a file.
+  ## Every column is created as a ```strCol``.
+  ##
+  ## This is useful if you want to read a file
+  ## and filter out columns before manualy creating a schema.
+  let header = staticRead(file).splitLines[0]
+  createSchemaFromHeader(header,sep)
+  
   
 template headerParser*(file: string,sep = ';'): untyped =
   ## creates a schema from a file header and calls ```schemaParser```
-  const schema = createSchemaFromHeader(file,sep)
+  const schema = createSchemaFromHeaderFile(file,sep)
   schemaParser(schema,sep)
   

--- a/src/nimdata/schema_parser.nim
+++ b/src/nimdata/schema_parser.nim
@@ -370,3 +370,24 @@ macro schemaParser*(schema: static[openarray[Column]], sep: static[char]): untyp
   when defined(checkMacros):
     #echo result.treerepr
     echo result.repr
+
+proc createSchemaFromHeader*(file: string,sep = ';'): seq[Column] =
+  ## Creates a schema from the header line of a file.
+  ## Every column is created as a ```strCol``.
+  ##
+  ## This is useful if you want to read a file
+  ## and filter out columns before manualy creating a schema.
+  let header = staticRead(file).splitLines[0].split(sep)
+  var i = 0
+  for str in header:
+      if str == "":
+          result.add(strCol("unnamed" & $i))
+          i += 1
+      else:
+          result.add(strCol(str))
+  
+template headerParser*(file: string,sep = ';'): untyped =
+  ## creates a schema from a file header and calls ```schemaParser```
+  const schema = createSchemaFromHeader(file,sep)
+  schemaParser(schema,sep)
+  


### PR DESCRIPTION
## Use-Case
This adds a function to create a simple schema from the header of a csv file.
The columns are created as string-columns but after this step you can refer to any column by it's name.
I made this to be able to select only important columns in big files without manually creating a schema.

## Problem
- [x] At the moment the file-path needs to be absolute or else the file can't be opened.
  - fixed by moving the file-reading part into a template
- [ ] ```staticRead().splitLines[0]``` does not work for large files because ```splitLines``` needs to many iterations.