### PR TITLE
Adding necessary imports to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ For a complete reference of the supported operations in NimData refer to the
 The following tutorial will give a brief introduction of the main
 functionality based on [this](examples/Bundesliga.csv) German soccer data set.
 
+### Modules
+
+We'll start by importing NimData:
+
+```nimrod
+import nimdata
+```
+
 ### Reading raw text data
 
 To create a data frame which simply iterates over the raw text content
@@ -149,6 +157,8 @@ Data can be filtered by using `filter`. For instance, we can filter the data to 
 of a certain team only:
 
 ```nimrod
+import strutils
+
 df.filter(record =>
     record.homeTeam.contains("Freiburg") or
     record.awayTeam.contains("Freiburg")
@@ -166,6 +176,7 @@ df.filter(record =>
 # | "1. FC Ko… | "SC Freib… |          2 |          0 |          5 |       1993 | 1993-09-0… |
 # +------------+------------+------------+------------+------------+------------+------------+
 ```
+_Note: Without the `strutils` module, `contains` will throw a type error here._
 
 Or search for games with many home goals:
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ We'll start by importing NimData:
 ```nimrod
 import nimdata
 ```
+We'll import additional modules as needed later in this tutorial.
 
 ### Reading raw text data
 


### PR DESCRIPTION
For the benefit of newcomers like myself, I added explicit instructions for importing `nimdata` and `strutils`. Note that without `strutils`, filtering by `contains` throws the following error:

```
.../.choosenim/toolchains/nim-1.4.4/lib/pure/times.nim(2110, 39) Hint: 'parse' cannot raise 'Defect' [XCannotRaiseY]
.../data.nim(18, 5) template/generic instantiation of `cache` from here
.../.nimble/pkgs/nimdata-0.1.0/nimdata.nim(545, 8) Warning: method has lock level 0, but another method has <unknown> [LockLevel]
.../data.nim(21, 20) Error: type mismatch: got <string, string>
but expected one of: 
proc contains[T](a: openArray[T]; item: T): bool
  first type mismatch at position: 2
  required type for item: T
  but expression '"Freiburg"' is of type: string
2 other mismatching symbols have been suppressed; compile with --showAllMismatches:on to see them

expression: contains(record.homeTeam, "Freiburg")
```